### PR TITLE
Fixed `fraction` option being ignored (issue #2)

### DIFF
--- a/script/aivolver
+++ b/script/aivolver
@@ -61,29 +61,29 @@ $log->formatter( $formatter );
 my $deps   = join ', ', @{ $data{'dependent'} };
 my $ignore = join ', ', @{ $data{'ignore'} };
 $log->info("going to read train data $data{file}, ignoring '$ignore', dependent columns are '$deps'");
-my $inputdata = AI::FANN::Evolving::TrainData->new( 
-	'file'      => $data{'file'}, 
-	'dependent' => $data{'dependent'}, 
+my $inputdata = AI::FANN::Evolving::TrainData->new(
+	'file'      => $data{'file'},
+	'dependent' => $data{'dependent'},
 	'ignore'    => $data{'ignore'},
 );
 my ( $traindata, $testdata );
 if ( $data{'type'} and lc $data{'type'} eq 'continuous' ) {
-	( $traindata, $testdata ) = $inputdata->sample_data( $data{'partition'} );
+	( $traindata, $testdata ) = $inputdata->sample_data( $data{'fraction'} );
 }
 else {
-	( $traindata, $testdata ) = $inputdata->partition_data( $data{'partition'} );
+	( $traindata, $testdata ) = $inputdata->partition_data( $data{'fraction'} );
 }
 
 $log->info("number of training data records: ".$traindata->size);
 $log->info("number of test data records: ".$testdata->size);
 
 # create first work dir
-my $wd  = delete $experiment{'workdir'}; 
+my $wd  = delete $experiment{'workdir'};
 make_path($wd);
 $wd .= '/0';
 
 # create the experiment
-my $exp = AI::FANN::Evolving::Experiment->new( 
+my $exp = AI::FANN::Evolving::Experiment->new(
 	'traindata' => $traindata->to_fann,
 	'env'       => $testdata->to_fann,
 	'workdir'   => $wd,
@@ -158,12 +158,12 @@ Defines the location of a file of input data.
 
 Fraction of input data to use for training (versus testing).
 
-=back 
+=back
 
 =item B<-i/--initialize <key=valueE<gt>>
 
 The C<initialize> argument is used multiple times, each time followed by a key/value
-pair that defines one of the initialization settings for the (genetic) structure of the 
+pair that defines one of the initialization settings for the (genetic) structure of the
 evolving population. The key/value pairs are as follows:
 
 =over
@@ -203,7 +203,7 @@ p of a trait mutating.
 
 Proportion of population contributing to next generation.
 
-=item B<ngens=<numberE<gt>> 
+=item B<ngens=<numberE<gt>>
 
 Number of generations. This should be the longer the better, at least while the
 fitness is still improving.
@@ -218,28 +218,28 @@ Output directory.
 
 =head1 DESCRIPTION
 
-Artificial neural networks (ANNs) are decision-making machines that develop their 
-capabilities by training on input data. During this training, the ANN builds a 
+Artificial neural networks (ANNs) are decision-making machines that develop their
+capabilities by training on input data. During this training, the ANN builds a
 topology of input neurons, hidden neurons, and output neurons that respond to signals
 in ways (and with sensitivities) that are determined by a variety of parameters. How
 these parameters will interact to give rise to the final functionality of the ANN is
 hard to predict I<a priori>, but can be optimized in a variety of ways.
 
-C<aivolver> is a program that does this by evolving parameter settings using a genetic 
-algorithm that runs for a number of generations determined by C<ngens>. During this 
-process it writes the intermediate ANNs into the C<workdir> until the best result is 
+C<aivolver> is a program that does this by evolving parameter settings using a genetic
+algorithm that runs for a number of generations determined by C<ngens>. During this
+process it writes the intermediate ANNs into the C<workdir> until the best result is
 written to the C<outfile>.
 
-The genetic algorithm proceeds by simulating a population of C<individual_count> diploid 
-individuals that each have C<chromosome_count> chromosomes whose C<gene_count> genes 
-encode the parameters of the ANN. During each generation, each individual is trained 
-on a sample data set, and the individual's fitness is then calculated by testing its 
-predictive abilities on an out-of-sample data set. The fittest individuals (whose 
-fraction of the total is determined by C<reproduction_rate>) are selected for breeding 
+The genetic algorithm proceeds by simulating a population of C<individual_count> diploid
+individuals that each have C<chromosome_count> chromosomes whose C<gene_count> genes
+encode the parameters of the ANN. During each generation, each individual is trained
+on a sample data set, and the individual's fitness is then calculated by testing its
+predictive abilities on an out-of-sample data set. The fittest individuals (whose
+fraction of the total is determined by C<reproduction_rate>) are selected for breeding
 in proportion to their fitness.
 
-Before breeding, each individual undergoes a process of mutation, where a fraction of 
-the ANN parameters is randomly perturbed. Both the size of the fraction and the 
+Before breeding, each individual undergoes a process of mutation, where a fraction of
+the ANN parameters is randomly perturbed. Both the size of the fraction and the
 maximum extent of the perturbation is determined by C<mutation_rate>. Subsequently, the
 homologous chromosomes recombine (i.e. exchange parameters) at a rate determined by
 C<crossover_rate>, which then results in (haploid) gametes. These gametes are fused with
@@ -262,15 +262,15 @@ The C<ID> column contains a unique identifier (a string) for each record in the 
 
 =item B<CLASS>
 
-Each C<CLASS> column (multiple are allowed) specifies the classification that should 
+Each C<CLASS> column (multiple are allowed) specifies the classification that should
 emerge from one of the output neurons. Often this would be an integer, for example
-either C<1> or C<-1> for a binary classification. The number of C<CLASS> columns 
+either C<1> or C<-1> for a binary classification. The number of C<CLASS> columns
 determines the number of outputs in the ANN.
 
 =item B<[others]>
 
-All other columns are interpreted as the predictor columns from which the ANN must 
-derive its capacity for classification. Normally these are continuous values, which 
+All other columns are interpreted as the predictor columns from which the ANN must
+derive its capacity for classification. Normally these are continuous values, which
 are normalized between all records, e.g. in a range between -1 and 1.
 
 =back


### PR DESCRIPTION
Some trailing spaces were automatically removed in the process. Script fails when fraction is set to 1.0.
